### PR TITLE
feat: Gesangbuch-Dashboard-Issues #47–#52 & #54

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,11 @@ VITE_NOTENTEXT_ROLES=
 # to be listed in VITE_KLEINER_KREIS_USERS. Leave empty to rely solely on that list.
 VITE_KLEINER_KREIS_ROLES=Super-Editor,Administrator
 
+# Comma-separated Directus role names allowed to access the Superadmin tools
+# (e.g. the Nummerngenerierung view, which writes liednummer2026/choralbuchNummer
+# directly to Directus). Defaults to "Administrator" when unset.
+VITE_SUPERADMIN_ROLES=Administrator
+
 # Directus folder UUID that notentext uploads (SVG/MXL) are placed into.
 # Leave empty to upload to the instance default folder (root).
 VITE_NOTENTEXT_FOLDER_ID=

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,17 @@
 // Service Worker for caching songs and documents
 
-const CACHE_VERSION = 'v1';
+// v2 (Issue #52): song/item data is now served network-first instead of
+// cache-first. The old cache-first strategy could serve a song/text response up
+// to an hour old, so a corrector who saved a strophe and later reloaded got the
+// stale cached version back — their correction appeared to "revert". The cache
+// is now only a fallback for when the network is unavailable (offline). Bumping
+// the version also purges the old v1 caches (see the activate handler) so
+// existing clients drop any stale entries on update.
+const CACHE_VERSION = 'v2';
 const SONG_CACHE_NAME = `song-data-${CACHE_VERSION}`;
 const DOCUMENT_CACHE_NAME = `documents-${CACHE_VERSION}`;
 
+// Only relevant as an offline fallback now that song data is network-first.
 const SONG_CACHE_DURATION = 60 * 60 * 1000; // 1 hour in milliseconds
 const DOCUMENT_CACHE_DURATION = 7 * 24 * 60 * 60 * 1000; // 1 week in milliseconds
 
@@ -48,21 +56,37 @@ function openCacheDB() {
     });
 }
 
-// Helper to determine if a URL should be cached
+// Helper to determine if a URL should be cached and with which strategy.
+//   'network-first' → mutable data: always fetch fresh when online, fall back to
+//                     the cache only on network failure (offline).
+//   'cache-first'   → effectively-immutable file content: serve from cache while
+//                     fresh, otherwise revalidate from the network.
 function shouldCacheUrl(url) {
     const urlObj = new URL(url);
     const pathname = urlObj.pathname;
 
-    // Cache song data requests (includes file metadata)
+    // Song/item data (and file metadata) is mutable — correctors edit it. Serve
+    // it network-first so a save is never masked by a stale cached copy (#52).
     if (pathname.includes('/items/') || pathname.includes('/files')) {
         console.log('[SW] URL matches song data pattern:', pathname);
-        return { cache: true, name: SONG_CACHE_NAME, duration: SONG_CACHE_DURATION };
+        return {
+            cache: true,
+            name: SONG_CACHE_NAME,
+            duration: SONG_CACHE_DURATION,
+            strategy: 'network-first',
+        };
     }
 
-    // Cache document/asset requests (actual file content)
+    // Document/asset requests are the actual (content-addressed) file bytes and
+    // can safely be served cache-first.
     if (pathname.includes('/assets/')) {
         console.log('[SW] URL matches document pattern:', pathname);
-        return { cache: true, name: DOCUMENT_CACHE_NAME, duration: DOCUMENT_CACHE_DURATION };
+        return {
+            cache: true,
+            name: DOCUMENT_CACHE_NAME,
+            duration: DOCUMENT_CACHE_DURATION,
+            strategy: 'cache-first',
+        };
     }
 
     console.log('[SW] URL does not match cache patterns:', pathname);
@@ -183,71 +207,117 @@ self.addEventListener('fetch', (event) => {
                 return fetch(request);
             }
 
-            // Try to get from cache first
             const cache = await caches.open(cacheInfo.name);
-            console.log('[SW] Checking cache:', cacheInfo.name);
-            const cachedResponse = await cache.match(request);
 
-            if (cachedResponse) {
-                console.log('[SW] 📦 Found in cache, checking freshness...');
-                if (isCacheFresh(cachedResponse, cacheInfo.duration)) {
-                    console.log('[SW] ✅ Serving FRESH cache:', request.url);
-
-                    // Notify the client that data was loaded from cache
-                    const clients = await self.clients.matchAll();
-                    const cacheType = cacheInfo.name.includes('song') ? 'song' : 'document';
-                    console.log('[SW] Notifying clients of cache hit (type:', cacheType + ')');
-                    clients.forEach((client) => {
-                        client.postMessage({
-                            type: 'CACHE_HIT',
-                            url: request.url,
-                            cacheType: cacheType,
-                        });
-                    });
-
-                    return cachedResponse;
-                } else {
-                    console.log('[SW] ⏰ Cache is stale, will fetch from network');
-                }
-            } else {
-                console.log('[SW] ❌ Not found in cache');
+            if (cacheInfo.strategy === 'network-first') {
+                return networkFirst(request, cache, cacheInfo);
             }
-
-            // Fetch from network
-            try {
-                console.log('[SW] 🌐 Fetching from network:', request.url);
-                const networkResponse = await fetch(request);
-                console.log('[SW] Network response status:', networkResponse.status);
-
-                // Only cache successful responses
-                if (networkResponse && networkResponse.status === 200) {
-                    console.log('[SW] ✅ Caching network response');
-                    const responseToCache = await createCachedResponse(networkResponse, cacheInfo);
-                    await cache.put(request, responseToCache);
-                    console.log('[SW] ✅ Successfully cached response');
-                } else {
-                    console.log(
-                        '[SW] ⚠️ Not caching response (status:',
-                        networkResponse.status + ')',
-                    );
-                }
-
-                return networkResponse;
-            } catch (error) {
-                console.error('[SW] ❌ Network fetch failed:', error);
-
-                // If network fails and we have a cached response (even if stale), use it
-                if (cachedResponse) {
-                    console.log('[SW] ⚠️ Using STALE cache as fallback:', request.url);
-                    return cachedResponse;
-                }
-
-                console.error('[SW] ❌ No fallback available, throwing error');
-                throw error;
-            }
+            return cacheFirst(request, cache, cacheInfo);
         })(),
     );
 });
+
+// Network-first: always try the network so mutable data is never stale (#52).
+// The cache is updated on every successful response and only read back when the
+// network is unavailable (offline resilience).
+async function networkFirst(request, cache, cacheInfo) {
+    try {
+        console.log('[SW] 🌐 Network-first, fetching:', request.url);
+        const networkResponse = await fetch(request);
+        console.log('[SW] Network response status:', networkResponse.status);
+
+        if (networkResponse && networkResponse.status === 200) {
+            const responseToCache = await createCachedResponse(networkResponse, cacheInfo);
+            await cache.put(request, responseToCache);
+            console.log('[SW] ✅ Updated cache from network');
+        }
+
+        return networkResponse;
+    } catch (error) {
+        console.error('[SW] ❌ Network fetch failed:', error);
+
+        // Offline fallback: serve whatever we have, even if stale.
+        const cachedResponse = await cache.match(request);
+        if (cachedResponse) {
+            console.log('[SW] ⚠️ Offline — using cached fallback:', request.url);
+            const clients = await self.clients.matchAll();
+            const cacheType = cacheInfo.name.includes('song') ? 'song' : 'document';
+            clients.forEach((client) => {
+                client.postMessage({
+                    type: 'CACHE_HIT',
+                    url: request.url,
+                    cacheType: cacheType,
+                });
+            });
+            return cachedResponse;
+        }
+
+        console.error('[SW] ❌ No fallback available, throwing error');
+        throw error;
+    }
+}
+
+// Cache-first: serve fresh cache immediately, otherwise revalidate from network.
+// Used for effectively-immutable file bytes under /assets/.
+async function cacheFirst(request, cache, cacheInfo) {
+    console.log('[SW] Checking cache:', cacheInfo.name);
+    const cachedResponse = await cache.match(request);
+
+    if (cachedResponse) {
+        console.log('[SW] 📦 Found in cache, checking freshness...');
+        if (isCacheFresh(cachedResponse, cacheInfo.duration)) {
+            console.log('[SW] ✅ Serving FRESH cache:', request.url);
+
+            // Notify the client that data was loaded from cache
+            const clients = await self.clients.matchAll();
+            const cacheType = cacheInfo.name.includes('song') ? 'song' : 'document';
+            console.log('[SW] Notifying clients of cache hit (type:', cacheType + ')');
+            clients.forEach((client) => {
+                client.postMessage({
+                    type: 'CACHE_HIT',
+                    url: request.url,
+                    cacheType: cacheType,
+                });
+            });
+
+            return cachedResponse;
+        } else {
+            console.log('[SW] ⏰ Cache is stale, will fetch from network');
+        }
+    } else {
+        console.log('[SW] ❌ Not found in cache');
+    }
+
+    // Fetch from network
+    try {
+        console.log('[SW] 🌐 Fetching from network:', request.url);
+        const networkResponse = await fetch(request);
+        console.log('[SW] Network response status:', networkResponse.status);
+
+        // Only cache successful responses
+        if (networkResponse && networkResponse.status === 200) {
+            console.log('[SW] ✅ Caching network response');
+            const responseToCache = await createCachedResponse(networkResponse, cacheInfo);
+            await cache.put(request, responseToCache);
+            console.log('[SW] ✅ Successfully cached response');
+        } else {
+            console.log('[SW] ⚠️ Not caching response (status:', networkResponse.status + ')');
+        }
+
+        return networkResponse;
+    } catch (error) {
+        console.error('[SW] ❌ Network fetch failed:', error);
+
+        // If network fails and we have a cached response (even if stale), use it
+        if (cachedResponse) {
+            console.log('[SW] ⚠️ Using STALE cache as fallback:', request.url);
+            return cachedResponse;
+        }
+
+        console.error('[SW] ❌ No fallback available, throwing error');
+        throw error;
+    }
+}
 
 // Message event - handle commands from the client
 self.addEventListener('message', (event) => {

--- a/src/assets/js/nummerngenerierung.js
+++ b/src/assets/js/nummerngenerierung.js
@@ -1,0 +1,211 @@
+// Portierung der Python-Skripte 11 (Choralbuchnummer) und 12 (Liednummer 2026)
+// aus gb-scripts/app. Reine Logik ohne Netzwerkzugriff, damit sie gut testbar
+// bleibt: die View lädt die Daten, ruft die Plan-Funktionen auf, zeigt das
+// Ergebnis als Vorschau an und schreibt es anschließend nach Directus.
+//
+// Issue #54: Gefiltert wird ausschließlich nach status === 'accepted'
+// ("Bewertet und genommen"). Die frühere zusätzliche Bedingung auf die
+// Kleiner-Kreis-Bewertung "Rein" entfällt. Das Filtern übernimmt die View beim
+// Laden – die Plan-Funktionen erwarten bereits nur die akzeptierten Lieder.
+
+// Sortierschlüssel wie in den Skripten: NFKD-Normalisierung, diakritische
+// Zeichen entfernen, casefold (inkl. ß -> ss), Satz-/Sonderzeichen ignorieren und
+// trimmen.
+//
+// Anders als die Python-Skripte (die nur Diakritika/Groß-/Kleinschreibung
+// behandelten) werden hier zusätzlich Satz- und Sonderzeichen ignoriert: ein
+// Komma, Anführungszeichen, Bindestrich o. ä. soll die alphabetische Reihenfolge
+// nicht beeinflussen ("O Mensch, bewein..." sortiert wie "O Mensch bewein..."). So
+// entspricht die generierte Reihenfolge der erwarteten Titel-Sortierung.
+//
+// Reihenfolge der Schritte ist wichtig: erst die kombinierenden Diakritika
+// ENTFERNEN (sonst würde "é" = e+◌́ zu "e " statt "e"), danach Sonderzeichen durch
+// ein Leerzeichen ERSETZEN. Buchstaben/Ziffern werden Unicode-weit erhalten, damit
+// fremdsprachige Titel nicht zerstört werden.
+export function sortKey(titel) {
+    if (!titel) return '';
+    return titel
+        .normalize('NFKD')
+        .replace(/[̀-ͯ]/g, '') // Diakritika (Umlaute etc.) entfernen
+        .toLowerCase()
+        .replace(/ß/g, 'ss')
+        .replace(/[^\p{L}\p{N}\s]/gu, ' ') // Satz-/Sonderzeichen -> Leerzeichen
+        .replace(/\s+/g, ' ') // Mehrfach-Leerzeichen zusammenfassen
+        .trim();
+}
+
+function compareIds(a, b) {
+    const na = Number(a);
+    const nb = Number(b);
+    if (Number.isFinite(na) && Number.isFinite(nb)) return na - nb;
+    const sa = String(a);
+    const sb = String(b);
+    return sa < sb ? -1 : sa > sb ? 1 : 0;
+}
+
+// Vergleich nach (Sortierschlüssel des Titels, id) – wie die Python-Skripte
+// (Codepoint-Ordnung des Schlüssels, kein locale-spezifisches Sortieren).
+export function compareByTitle(a, b) {
+    const ka = sortKey(a.titel);
+    const kb = sortKey(b.titel);
+    if (ka < kb) return -1;
+    if (ka > kb) return 1;
+    return compareIds(a.id, b.id);
+}
+
+function toNumberOrNull(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+}
+
+// Master-Fassung (deutsche Liedfassung) eines Liedes. REST liefert die M2O-
+// Beziehung je nach `fields`-Angabe als reine id oder als { id }.
+function masterIdOf(song) {
+    const dlf = song?.deutscheLiedfassung;
+    if (dlf === null || dlf === undefined) return null;
+    return typeof dlf === 'object' ? (dlf.id ?? null) : dlf;
+}
+
+// --- Liednummer 2026 (Skript 12) ------------------------------------------
+// acceptedSongs:  [{ id, titel, liednummer2026, deutscheLiedfassung }]
+// numberedSongs:  [{ id, titel, liednummer2026 }] – alle Lieder mit gesetzter Nummer
+export function planLiednummern(acceptedSongs, numberedSongs = []) {
+    const sorted = [...acceptedSongs].sort(compareByTitle);
+    const byId = new Map(sorted.map((s) => [s.id, s]));
+    const numbers = new Map();
+
+    // 1. Durchlauf: "primäre" Lieder (ohne deutsche Liedfassung) fortlaufend
+    //    durchnummerieren; abgeleitete Lieder zurückstellen.
+    let counter = 0;
+    const derived = [];
+    for (const song of sorted) {
+        if (masterIdOf(song) != null) {
+            derived.push(song);
+            continue;
+        }
+        counter += 1;
+        numbers.set(song.id, counter);
+    }
+
+    // 2. Durchlauf: abgeleitete Lieder übernehmen die Nummer ihrer Master-
+    //    Fassung; Ketten werden bis zur primären Fassung aufgelöst. Lieder, deren
+    //    Master nicht (mehr) akzeptiert/auflösbar ist, werden übersprungen.
+    const skipped = [];
+    for (const song of derived) {
+        const masterNumber = resolveMasterNumber(masterIdOf(song), byId, numbers);
+        if (masterNumber == null) {
+            skipped.push({ id: song.id, titel: song.titel, masterId: masterIdOf(song) });
+            continue;
+        }
+        numbers.set(song.id, masterNumber);
+    }
+
+    const numbered = [...numbers.entries()]
+        .map(([id, next]) => {
+            const song = byId.get(id);
+            const current = toNumberOrNull(song?.liednummer2026);
+            return {
+                id,
+                titel: song?.titel ?? '',
+                current,
+                next,
+                isMaster: masterIdOf(song) == null,
+                changed: current !== next,
+            };
+        })
+        .sort((a, b) => a.next - b.next || compareByTitle(a, b));
+
+    const numberedIds = new Set(numbers.keys());
+    const toClear = numberedSongs
+        .filter((s) => !numberedIds.has(s.id))
+        .map((s) => ({ id: s.id, titel: s.titel, current: toNumberOrNull(s.liednummer2026) }));
+
+    const changed = numbered.filter((n) => n.changed);
+    return {
+        field: 'liednummer2026',
+        collection: 'gesangbuchlied',
+        numbered,
+        changed,
+        toClear,
+        skipped,
+        counts: {
+            total: numbered.length,
+            changed: changed.length,
+            unchanged: numbered.length - changed.length,
+            clear: toClear.length,
+            skipped: skipped.length,
+        },
+    };
+}
+
+function resolveMasterNumber(startId, byId, numbers) {
+    const seen = new Set();
+    let currentId = startId;
+    while (currentId != null && !seen.has(currentId)) {
+        seen.add(currentId);
+        if (numbers.has(currentId)) return numbers.get(currentId);
+        const current = byId.get(currentId);
+        if (!current) return null;
+        currentId = masterIdOf(current);
+    }
+    return null;
+}
+
+// --- Choralbuchnummer (Skript 11) -----------------------------------------
+// acceptedSongs:     [{ id, melodie: { id, titel, choralbuchNummer } | null }]
+// numberedMelodies:  [{ id, titel, choralbuchNummer }] – alle Melodien mit Nummer
+export function planChoralbuchNummern(acceptedSongs, numberedMelodies = []) {
+    // Eindeutige Melodien der akzeptierten Lieder (erstes Vorkommen gewinnt).
+    const unique = new Map();
+    let skippedNoMelodie = 0;
+    for (const song of acceptedSongs) {
+        const mel = song?.melodie;
+        const melId = mel && typeof mel === 'object' ? mel.id : mel;
+        if (melId == null) {
+            skippedNoMelodie += 1;
+            continue;
+        }
+        if (!unique.has(melId)) {
+            unique.set(melId, {
+                id: melId,
+                titel: mel?.titel ?? '',
+                choralbuchNummer: toNumberOrNull(mel?.choralbuchNummer),
+            });
+        }
+    }
+
+    const melodies = [...unique.values()].sort(compareByTitle);
+    const numbered = melodies.map((m, idx) => {
+        const next = idx + 1;
+        return {
+            id: m.id,
+            titel: m.titel,
+            current: m.choralbuchNummer,
+            next,
+            changed: m.choralbuchNummer !== next,
+        };
+    });
+
+    const acceptedIds = new Set(unique.keys());
+    const toClear = numberedMelodies
+        .filter((m) => !acceptedIds.has(m.id))
+        .map((m) => ({ id: m.id, titel: m.titel, current: toNumberOrNull(m.choralbuchNummer) }));
+
+    const changed = numbered.filter((n) => n.changed);
+    return {
+        field: 'choralbuchNummer',
+        collection: 'melodie',
+        numbered,
+        changed,
+        toClear,
+        skippedNoMelodie,
+        counts: {
+            total: numbered.length,
+            changed: changed.length,
+            unchanged: numbered.length - changed.length,
+            clear: toClear.length,
+            skippedNoMelodie,
+        },
+    };
+}

--- a/src/components/SongRelated/StrophenList.vue
+++ b/src/components/SongRelated/StrophenList.vue
@@ -336,19 +336,50 @@
             <v-btn
                 color="primary"
                 variant="elevated"
-                :loading="isSaving"
-                :disabled="isSaving"
+                :loading="isSaving || checkingConflict"
+                :disabled="isSaving || checkingConflict"
                 @click="saveEditedStrophen"
             >
                 <v-icon start>mdi-content-save</v-icon>
                 Speichern
             </v-btn>
-            <v-btn color="grey" variant="outlined" :disabled="isSaving" @click="cancelEdit">
+            <v-btn
+                color="grey"
+                variant="outlined"
+                :disabled="isSaving || checkingConflict"
+                @click="cancelEdit"
+            >
                 <v-icon start>mdi-close</v-icon>
                 Abbrechen
             </v-btn>
         </div>
     </div>
+
+    <!-- Konflikt-Warnung (Issue #52): der Text wurde zwischenzeitlich serverseitig
+         geändert. Der Nutzer entscheidet, ob er überschreibt. -->
+    <v-dialog v-model="conflictDialog" max-width="520" persistent>
+        <v-card>
+            <v-card-title class="d-flex align-center ga-2">
+                <v-icon color="warning">mdi-alert</v-icon>
+                Zwischenzeitlich geändert
+            </v-card-title>
+            <v-card-text>
+                Dieser Text wurde geöffnet bzw. zuletzt geladen und in der Zwischenzeit von jemand
+                anderem (oder in einem anderen Tab) gespeichert. Wenn du jetzt speicherst,
+                <strong>überschreibst du diese neueren Änderungen</strong>.
+                <div class="mt-3 text-medium-emphasis text-body-2">
+                    Empfehlung: Abbrechen, die Seite neu laden und deine Änderungen erneut eintragen.
+                </div>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn variant="text" @click="conflictDialog = false">Abbrechen</v-btn>
+                <v-btn color="warning" variant="flat" :loading="isSaving" @click="forceSave">
+                    Trotzdem speichern
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
 </template>
 
 <script>
@@ -408,6 +439,13 @@ export default {
         editedStrophen: [],
         isSaving: false,
         saveError: null,
+        // Konflikterkennung (Issue #52): date_updated des Textes zum Zeitpunkt des
+        // Bearbeitungsstarts. Beim Speichern wird der aktuelle Server-Wert dagegen
+        // geprüft, um zwischenzeitliche Änderungen anderer Nutzer zu erkennen.
+        loadedDateUpdated: null,
+        conflictDialog: false,
+        conflictInfo: null,
+        checkingConflict: false,
         korrekturlesung1: false,
         korrekturlesung1_alle_Strophen: false,
         korrekturlesung2: false,
@@ -448,6 +486,12 @@ export default {
                 }));
                 this.editedStrophen = _.cloneDeep(this.show_strophen);
                 this.syncKorrekturlesung(newText);
+                // Solange NICHT bearbeitet wird, gilt der jeweils geladene Stand
+                // als Bearbeitungsbasis. Während des Bearbeitens bleibt die Basis
+                // bewusst stehen, damit zwischenzeitliche Änderungen erkannt werden.
+                if (!this.editMode) {
+                    this.loadedDateUpdated = newText?.date_updated ?? null;
+                }
             },
             deep: true,
         },
@@ -457,6 +501,8 @@ export default {
                 this.editedStrophen = _.cloneDeep(this.show_strophen);
                 // Reset korrekturlesung flags from text object
                 this.syncKorrekturlesung(this.text);
+                // Bearbeitungsbasis für die Konflikterkennung festhalten.
+                this.loadedDateUpdated = this.text?.date_updated ?? null;
             }
         },
     },
@@ -471,6 +517,9 @@ export default {
 
         // Initialize korrekturlesung flags from text object
         this.syncKorrekturlesung(this.text);
+
+        // Bearbeitungsbasis für die Konflikterkennung (Issue #52).
+        this.loadedDateUpdated = this.text?.date_updated ?? null;
 
         // Load settings from localStorage
         this.loadSettings();
@@ -631,13 +680,49 @@ export default {
             }
         },
 
+        // Konflikterkennung (Issue #52): Vor dem Speichern prüfen, ob der Text seit
+        // dem Bearbeitungsstart serverseitig verändert wurde. Falls ja, warnen und
+        // den Nutzer entscheiden lassen (überschreiben oder abbrechen) – statt
+        // stillschweigend fremde Änderungen zu überschreiben. Schlägt die Prüfung
+        // selbst fehl (z. B. offline), wird normal gespeichert (best effort).
         async saveEditedStrophen() {
+            this.saveError = null;
+            this.checkingConflict = true;
+            try {
+                const remote = await this.store.getTextDateUpdated(this.text.id);
+                const remoteDate = remote?.date_updated ?? null;
+                if (
+                    this.loadedDateUpdated &&
+                    remoteDate &&
+                    remoteDate !== this.loadedDateUpdated
+                ) {
+                    this.conflictInfo = { remoteDate };
+                    this.conflictDialog = true;
+                    this.checkingConflict = false;
+                    return;
+                }
+            } catch (error) {
+                console.warn('Konfliktprüfung fehlgeschlagen, speichere trotzdem:', error);
+            } finally {
+                this.checkingConflict = false;
+            }
+
+            await this.performSave();
+        },
+
+        // Trotz erkannten Konflikts speichern (überschreibt den fremden Stand).
+        async forceSave() {
+            this.conflictDialog = false;
+            await this.performSave();
+        },
+
+        async performSave() {
             this.isSaving = true;
             this.saveError = null;
 
             try {
                 // Save to Directus backend via store
-                await this.store.updateTextStrophes(
+                const result = await this.store.updateTextStrophes(
                     this.text.id,
                     this.editedStrophen.map((strophe, index) => {
                         const payload = {
@@ -663,6 +748,11 @@ export default {
                     ...strophe,
                     strophe: this.editedStrophen[index].strophe,
                 }));
+
+                // Bearbeitungsbasis auf den frisch gespeicherten Stand setzen, damit
+                // ein direkt folgendes Speichern nicht fälschlich als Konflikt gilt.
+                const savedDate = result?.data?.date_updated;
+                if (savedDate) this.loadedDateUpdated = savedDate;
 
                 // Emit event to close edit mode
                 this.$emit('edit-completed');

--- a/src/components/util/MenuList.vue
+++ b/src/components/util/MenuList.vue
@@ -42,6 +42,12 @@ const notentextRoles = (import.meta.env.VITE_NOTENTEXT_ROLES || '')
     .map((s) => s.trim())
     .filter(Boolean);
 
+// Rollen für die Superadmin-Werkzeuge (Standard: "Administrator").
+const superadminRoles = (import.meta.env.VITE_SUPERADMIN_ROLES || 'Administrator')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
 export default {
     name: 'MenuList',
     props: {
@@ -137,6 +143,21 @@ export default {
                         route: '/notentext-hochladen',
                         icon: 'mdi-cloud-upload',
                         requiredRoles: notentextRoles,
+                    },
+                ],
+            },
+            {
+                // Eigener Bereich, unabhängig vom Kleiner-Kreis-Modus sichtbar –
+                // erscheint nur, wenn der Nutzer eine Superadmin-Rolle hat (der
+                // einzige Eintrag wird sonst herausgefiltert).
+                title: 'Superadmin',
+                public: true,
+                items: [
+                    {
+                        name: 'Nummerngenerierung',
+                        route: '/nummerngenerierung',
+                        icon: 'mdi-shield-crown',
+                        requiredRoles: superadminRoles,
                     },
                 ],
             },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,13 @@ const notentextRoles = (import.meta.env.VITE_NOTENTEXT_ROLES || '')
     .map((s) => s.trim())
     .filter(Boolean);
 
+// Rollen mit Zugriff auf die Superadmin-Werkzeuge (z. B. Nummerngenerierung).
+// Standard: "Administrator", falls VITE_SUPERADMIN_ROLES nicht gesetzt ist.
+const superadminRoles = (import.meta.env.VITE_SUPERADMIN_ROLES || 'Administrator')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
 const routes = [
     {
         path: '/',
@@ -132,6 +139,15 @@ const routes = [
                 component: () =>
                     import(
                         /* webpackChunkName: "noten-upload" */ '@/views/NotentextUploadView.vue'
+                    ),
+            },
+            {
+                path: 'nummerngenerierung',
+                name: 'Nummerngenerierung',
+                meta: { requiredRoles: superadminRoles },
+                component: () =>
+                    import(
+                        /* webpackChunkName: "nummerngenerierung" */ '@/views/NummerngenerierungView.vue'
                     ),
             },
         ],

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -8,6 +8,18 @@ import { formatAuthors } from '@/assets/js/authorFormat';
 import router from '@/router';
 import { useUserStore } from '@/store/user';
 
+// True, wenn der entfernte Zeitstempel echt neuer ist als der lokale (Issue #52,
+// Konflikterkennung). Fehlt der entfernte Wert, gilt nichts als neuer; fehlt nur
+// der lokale, gilt jeder vorhandene entfernte Wert als neuer.
+function isTimestampNewer(remote, local) {
+    if (!remote) return false;
+    if (!local) return true;
+    const r = Date.parse(remote);
+    const l = Date.parse(local);
+    if (Number.isNaN(r) || Number.isNaN(l)) return false;
+    return r > l;
+}
+
 export const useAppStore = defineStore('app', {
     state: () => ({
         data_loaded: false,
@@ -745,6 +757,60 @@ export const useAppStore = defineStore('app', {
             }
         },
 
+        // Aktuelles date_updated eines Textes frisch vom Server holen (Issue #52).
+        // Für die Konflikterkennung beim Speichern von Strophentexten: weicht der
+        // Wert vom beim Bearbeitungsstart geladenen ab, hat zwischenzeitlich jemand
+        // anderes gespeichert.
+        async getTextDateUpdated(textId) {
+            const resp = await axios.get(
+                `${import.meta.env.VITE_BACKEND_URL}/items/text/${textId}`,
+                { params: { fields: 'id,date_updated,user_updated' } },
+            );
+            return resp.data?.data ?? null;
+        },
+
+        // Prüft, ob für die angegebenen Lieder im Directus ein neuerer Stand
+        // existiert als im Store geladen (Issue #52, Export-Warnung). Vergleicht
+        // date_updated des Liedes UND des zugehörigen Textes. Liefert die Lieder
+        // mit neuerem Stand (id, titel).
+        async checkSongsFreshness(songIds) {
+            const ids = (songIds || []).filter((id) => id != null);
+            if (ids.length === 0) return [];
+            const resp = await axios.get(
+                `${import.meta.env.VITE_BACKEND_URL}/items/gesangbuchlied`,
+                {
+                    params: {
+                        filter: JSON.stringify({ id: { _in: ids } }),
+                        fields: 'id,titel,date_updated,textId.id,textId.date_updated',
+                        limit: -1,
+                    },
+                },
+            );
+            const remoteList = resp.data?.data ?? [];
+            const localById = new Map(this.gesangbuchlied.map((l) => [l.id, l]));
+            const stale = [];
+            for (const remote of remoteList) {
+                const local = localById.get(remote.id);
+                if (!local) continue;
+                const liedNewer = isTimestampNewer(remote.date_updated, local.date_updated);
+                const textNewer = isTimestampNewer(
+                    remote.textId?.date_updated,
+                    local.text?.date_updated,
+                );
+                if (liedNewer || textNewer) {
+                    stale.push({ id: remote.id, titel: remote.titel || local.titel || '' });
+                }
+            }
+            return stale;
+        },
+
+        // Alle Daten neu laden (umgeht die data_loaded-Sperre). Für die
+        // „Daten neu laden"-Aktion der Export-Frische-Warnung (Issue #52).
+        async reloadData() {
+            this.data_loaded = false;
+            await this.loadData();
+        },
+
         async updateTextStrophes(textId, strophes, korrektur = null) {
             const controller = new AbortController();
             this.currentRequests.push(controller);
@@ -788,6 +854,13 @@ export const useAppStore = defineStore('app', {
                 if (textIndex !== -1) {
                     this.text[textIndex].strophenEinzeln = strophes;
                     this.text[textIndex].text_changed_at = textChangedAt;
+                    // Directus liefert den aktualisierten Datensatz inkl. neuem
+                    // date_updated zurück – im Store nachziehen, damit die
+                    // Konflikterkennung (Issue #52) auf dem aktuellen Stand bleibt.
+                    const serverDateUpdated = response.data?.data?.date_updated;
+                    if (serverDateUpdated) {
+                        this.text[textIndex].date_updated = serverDateUpdated;
+                    }
                     if (korrektur && typeof korrektur === 'object') {
                         KORREKTUR_FELDER.forEach((feld) => {
                             if (korrektur[feld] !== undefined) {

--- a/src/views/CorrectionView.vue
+++ b/src/views/CorrectionView.vue
@@ -8,6 +8,7 @@ import {
     chart_colors,
     chipColors,
     gesangbuch_kategorie_name_to_icon,
+    resolveLiednummer2026,
     status_mapping,
 } from '@/assets/js/utils.js';
 import NotenCarousel from '@/components/SongRelated/NotenCarousel.vue';
@@ -21,6 +22,20 @@ const store = useAppStore();
 const userStore = useUserStore();
 
 const { author, gesangbuchlieder } = store;
+
+// 2026er Liednummer pro Lied auflösen (inkl. Fallback über die deutsche
+// Liedfassung) – analog zu den Export-Ansichten. Wird in der Titelzeile vor dem
+// Titel angezeigt (Issue #47).
+const liednummer2026_by_id = computed(() => {
+    const map = {};
+    for (const l of gesangbuchlieder) {
+        if (l && l.id != null && l.liednummer2026) map[l.id] = l.liednummer2026;
+    }
+    return map;
+});
+function nummer2026Of(lied) {
+    return resolveLiednummer2026(lied, liednummer2026_by_id.value);
+}
 
 const showSongs = ref(false);
 
@@ -647,6 +662,20 @@ const get_color = (category) => {
                                             size="small"
                                             class="me-1"
                                         />
+                                    </template>
+                                </v-tooltip>
+                                <v-tooltip
+                                    v-if="nummer2026Of(lied)"
+                                    text="Liednummer im Gesangbuch 2026"
+                                    location="bottom"
+                                >
+                                    <template #activator="{ props }">
+                                        <span
+                                            v-bind="props"
+                                            class="font-weight-bold text-primary me-1"
+                                        >
+                                            {{ nummer2026Of(lied) }}
+                                        </span>
                                     </template>
                                 </v-tooltip>
                                 {{ lied.titel }}

--- a/src/views/InhaltsverzeichnisExportView.vue
+++ b/src/views/InhaltsverzeichnisExportView.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue';
 import { useAppStore } from '@/store/app.js';
 import { storeToRefs } from 'pinia';
 import { resolveLiednummer2026 } from '@/assets/js/utils';
+import { isGenommen } from '@/assets/js/gesangbuchChecks';
 
 // Separater Export des Inhaltsverzeichnisses (Issue #45), das Janosch importieren
 // oder einfach kopieren kann. Zwei Varianten:
@@ -15,10 +16,10 @@ import { resolveLiednummer2026 } from '@/assets/js/utils';
 const store = useAppStore();
 const { gesangbuchlieder } = storeToRefs(store);
 
-// Bewertung „Rein" (angenommen) – wie in den übrigen Export-/Listenansichten.
-const isRein = (bezeichner) => !!bezeichner && bezeichner.toLowerCase().includes('rein');
-
-const only_rein = ref(true);
+// „Bewertet und genommen" = status === 'accepted' (Issue #51). Es wird bewusst
+// nach dem Status gefiltert und nicht mehr nach der Kleiner-Kreis-Bewertung
+// „Rein".
+const only_accepted = ref(true);
 const only_with_number = ref(false);
 
 const snackbar = ref(false);
@@ -47,22 +48,55 @@ function kategorienOf(lied) {
     return namen.length ? [...new Set(namen)] : [];
 }
 
-// Grundmenge: nach Filtern, mit aufgelöster Nummer angereichert.
-const songs = computed(() => {
+// Grundmenge: nach dem Status-Filter, mit aufgelöster Nummer angereichert.
+// Bewusst OHNE den „nur mit Liednummer"-Filter, damit die Kennzahlen (u. a.
+// „ohne Liednummer") aussagekräftig bleiben.
+const base_songs = computed(() => {
     let list = gesangbuchlieder.value.filter((l) => l && (l.titel || '').trim());
-    if (only_rein.value) {
-        list = list.filter((l) => isRein(l.bewertung_kleiner_kreis?.bezeichner));
+    if (only_accepted.value) {
+        list = list.filter((l) => isGenommen(l));
     }
-    let mapped = list.map((l) => ({
+    return list.map((l) => ({
         id: l.id,
         titel: (l.titel || '').trim(),
         nummer: nummerOf(l),
         kategorien: kategorienOf(l),
     }));
-    if (only_with_number.value) {
-        mapped = mapped.filter((s) => s.nummer !== '' && s.nummer != null);
+});
+
+// Anzeige-/Exportmenge: zusätzlich optional auf Lieder mit Nummer eingeschränkt.
+const songs = computed(() => {
+    if (!only_with_number.value) return base_songs.value;
+    return base_songs.value.filter((s) => s.nummer !== '' && s.nummer != null);
+});
+
+function hasNummer(s) {
+    return s.nummer !== '' && s.nummer != null;
+}
+
+// Differenzierte Kennzahlen für die Kopfzeile (Issue #50): Gesamtzahl, Anzahl
+// der Lieder, die sich eine Liednummer 2026 mit mindestens einem anderen Lied
+// teilen, höchste vergebene Liednummer und Lieder ohne Liednummer.
+const stats = computed(() => {
+    const list = base_songs.value;
+    const total = list.length;
+    const withNummer = list.filter(hasNummer);
+    const withoutNummer = total - withNummer.length;
+
+    let maxNummer = 0;
+    for (const s of withNummer) {
+        const n = leadingNummer(s);
+        if (n != null && n > maxNummer) maxNummer = n;
     }
-    return mapped;
+
+    const countByNummer = {};
+    for (const s of withNummer) {
+        const key = String(s.nummer);
+        countByNummer[key] = (countByNummer[key] || 0) + 1;
+    }
+    const duplicate = withNummer.filter((s) => countByNummer[String(s.nummer)] > 1).length;
+
+    return { total, withoutNummer, maxNummer: maxNummer || null, duplicate };
 });
 
 // Sortierung nach Liednummer 2026. Die Nummern wurden bereits in der
@@ -192,7 +226,57 @@ function copyByCategory() {
 <template>
     <div class="d-flex align-center flex-wrap ga-2 mb-2">
         <h1 class="me-4">Inhaltsverzeichnis-Export</h1>
-        <v-chip color="primary" variant="tonal">{{ songs.length }} Lieder</v-chip>
+        <v-tooltip text="Lieder insgesamt (Bewertet und genommen)" location="bottom">
+            <template #activator="{ props }">
+                <v-chip
+                    v-bind="props"
+                    color="primary"
+                    variant="tonal"
+                    prepend-icon="mdi-music"
+                >
+                    {{ stats.total }} Lieder
+                </v-chip>
+            </template>
+        </v-tooltip>
+        <v-tooltip
+            text="Lieder, die sich eine Liednummer 2026 mit mindestens einem anderen Lied teilen"
+            location="bottom"
+        >
+            <template #activator="{ props }">
+                <v-chip
+                    v-bind="props"
+                    :color="stats.duplicate ? 'warning' : undefined"
+                    variant="tonal"
+                    prepend-icon="mdi-content-duplicate"
+                >
+                    {{ stats.duplicate }} gleiche Nr.
+                </v-chip>
+            </template>
+        </v-tooltip>
+        <v-tooltip text="Höchste vergebene Liednummer 2026" location="bottom">
+            <template #activator="{ props }">
+                <v-chip
+                    v-bind="props"
+                    color="primary"
+                    variant="tonal"
+                    prepend-icon="mdi-pound"
+                >
+                    Höchste Nr.: {{ stats.maxNummer ?? '–' }}
+                </v-chip>
+            </template>
+        </v-tooltip>
+        <v-tooltip text="Lieder ohne Liednummer 2026" location="bottom">
+            <template #activator="{ props }">
+                <v-chip
+                    v-bind="props"
+                    :color="stats.withoutNummer ? 'warning' : undefined"
+                    variant="tonal"
+                    prepend-icon="mdi-help-circle-outline"
+                >
+                    {{ stats.withoutNummer }} ohne Nr.
+                </v-chip>
+            </template>
+        </v-tooltip>
     </div>
     <p class="text-body-2 text-medium-emphasis mb-4" style="max-width: 820px">
         Separater Export des Inhaltsverzeichnisses zum Importieren oder Kopieren – einmal
@@ -204,8 +288,8 @@ function copyByCategory() {
     <v-card class="mb-4">
         <v-card-text class="d-flex flex-wrap align-center ga-4">
             <v-checkbox
-                v-model="only_rein"
-                label="Nur angenommene (Rein)"
+                v-model="only_accepted"
+                label='Nur "Bewertet und genommen"'
                 color="success"
                 hide-details
                 density="comfortable"

--- a/src/views/NotenExportView.vue
+++ b/src/views/NotenExportView.vue
@@ -9,6 +9,7 @@ import { jsPDF } from 'jspdf';
 import 'svg2pdf.js';
 import JSZip from 'jszip';
 import { formatYearRange, formatAuthors } from '@/assets/js/authorFormat';
+import { isGenommen } from '@/assets/js/gesangbuchChecks';
 import GesangbuchLiedComponent from '@/components/SongRelated/GesangbuchLiedComponent.vue';
 
 const store = useAppStore();
@@ -19,11 +20,11 @@ const router = useRouter();
 const search = ref('');
 const filter_status = ref('set'); // 'set' | 'empty' | 'all'
 const hide_already_exported = ref(false);
-const only_rein = ref(true);
+// „Bewertet und genommen" = status === 'accepted' (Issue #49). Ersetzt den
+// früheren Filter nach der Kleiner-Kreis-Bewertung „Rein".
+const only_accepted = ref(true);
 const trim_whitespace = ref(false);
 const trim_padding = ref(8);
-
-const isRein = (bezeichner) => !!bezeichner && bezeichner.toLowerCase().includes('rein');
 
 const exporting = ref(false);
 const progress = ref({ done: 0, total: 0, current: '' });
@@ -238,7 +239,7 @@ const filtered_lieder = computed(() => {
             const has = !!lied.notentext;
             if (filter_status.value === 'set' && !has) return false;
             if (filter_status.value === 'empty' && has) return false;
-            if (only_rein.value && !isRein(lied.bewertung_kleiner_kreis?.bezeichner)) return false;
+            if (only_accepted.value && !isGenommen(lied)) return false;
             if (hide_already_exported.value && previously_exported_ids.value.has(lied.id))
                 return false;
             if (q) {
@@ -257,9 +258,14 @@ const filtered_lieder = computed(() => {
         });
 });
 
+// Kennzahlen beziehen sich immer auf die „Bewertet und genommen"-Lieder
+// (status === 'accepted') – unabhängig vom „Nur Bewertet und genommen"-Schalter
+// (Issue #49). Interessant ist, wie viele davon schon einen Notentext haben und
+// wie viele noch fehlen.
 const stats = computed(() => {
-    const total = all_lieder.value.length;
-    const with_notentext = all_lieder.value.filter((l) => !!l.notentext).length;
+    const accepted = all_lieder.value.filter((l) => isGenommen(l));
+    const total = accepted.length;
+    const with_notentext = accepted.filter((l) => !!l.notentext).length;
     const without = total - with_notentext;
     return { total, with_notentext, without };
 });
@@ -416,7 +422,22 @@ const export_candidates = computed(() =>
     filtered_lieder.value.filter((l) => !!l.notentext && selected_ids.value.has(l.id)),
 );
 
+// Höchste vergebene Liednummer 2026 über ALLE Lieder (nicht nur die
+// exportierbaren). Dient als Obergrenze der Lücken-Anzeige (Issue #48).
+const global_max_liednummer = computed(() => {
+    let max = NaN;
+    for (const lied of all_lieder.value) {
+        const n = liednummerOf(lied);
+        if (Number.isFinite(n) && (!Number.isFinite(max) || n > max)) max = n;
+    }
+    return max;
+});
+
 // Min/Max-Liednummer des Download-Bereichs (>= 2 Nummern nötig für eine Lücke).
+// Die Obergrenze ist bewusst die höchste insgesamt vergebene Liednummer 2026
+// (Issue #48) und nicht nur die höchste ausgewählte/exportierbare Nummer – so
+// werden auch noch fehlende Lieder oberhalb des Auswahl-Maximums als Lücke
+// sichtbar (man sieht besser, welche Liedtitel noch fehlen).
 const selection_range = computed(() => {
     const nums = new Set();
     for (const lied of export_candidates.value) {
@@ -424,7 +445,11 @@ const selection_range = computed(() => {
         if (Number.isFinite(n)) nums.add(n);
     }
     if (nums.size < 2) return null;
-    return { min: Math.min(...nums), max: Math.max(...nums), nums };
+    const min = Math.min(...nums);
+    const selMax = Math.max(...nums);
+    const gmax = global_max_liednummer.value;
+    const max = Number.isFinite(gmax) && gmax > selMax ? gmax : selMax;
+    return { min, max, nums };
 });
 
 function gapReason(lied) {
@@ -913,6 +938,62 @@ async function blobIsPdf(blob) {
     }
 }
 
+// --- Issue #52: Frische-Warnung vor dem Export ----------------------------
+// Beim Klick auf „exportieren" wird geprüft, ob für die ausgewählten Lieder im
+// Directus inzwischen ein neuerer Stand existiert (z. B. ein gerade korrigierter
+// Strophentext). Falls ja, wird gewarnt, statt einen veralteten Stand zu
+// exportieren.
+const freshness_dialog = ref(false);
+const freshness_checking = ref(false);
+const freshness_stale = ref([]);
+
+async function onExportClick() {
+    error_msg.value = '';
+    if (export_candidates.value.length === 0) {
+        error_msg.value = 'Keine Lieder ausgewählt.';
+        return;
+    }
+    freshness_checking.value = true;
+    try {
+        const ids = export_candidates.value.map((l) => l.id);
+        freshness_stale.value = await store.checkSongsFreshness(ids);
+    } catch (e) {
+        // Prüfung fehlgeschlagen (z. B. offline) -> Export nicht blockieren.
+        freshness_stale.value = [];
+    } finally {
+        freshness_checking.value = false;
+    }
+    if (freshness_stale.value.length > 0) {
+        freshness_dialog.value = true;
+        return;
+    }
+    runExport();
+}
+
+// „Daten neu laden" aus der Frische-Warnung: alles frisch holen und erneut prüfen.
+async function reloadAndRecheck() {
+    freshness_checking.value = true;
+    try {
+        await store.reloadData();
+        const ids = export_candidates.value.map((l) => l.id);
+        freshness_stale.value = await store.checkSongsFreshness(ids);
+        if (freshness_stale.value.length === 0) {
+            freshness_dialog.value = false;
+            snackbar_message.value = 'Daten aktualisiert – jetzt auf dem neuesten Stand.';
+            snackbar.value = true;
+        }
+    } catch (e) {
+        error_msg.value = 'Aktualisieren fehlgeschlagen.';
+    } finally {
+        freshness_checking.value = false;
+    }
+}
+
+function exportAnyway() {
+    freshness_dialog.value = false;
+    runExport();
+}
+
 async function runExport() {
     error_msg.value = '';
     const candidates = export_candidates.value;
@@ -1028,7 +1109,7 @@ async function runExport() {
         filter: {
             status: filter_status.value,
             search: search.value,
-            only_rein: only_rein.value,
+            only_accepted: only_accepted.value,
             hide_already_exported: hide_already_exported.value,
         },
         options: {
@@ -1116,9 +1197,31 @@ function formatDate(iso) {
 <template>
     <div class="d-flex align-center flex-wrap ga-2 mb-4">
         <h1 class="me-4">Notentext-Export</h1>
-        <v-chip color="primary" variant="tonal">Gesamt: {{ stats.total }}</v-chip>
-        <v-chip color="success" variant="tonal">Mit notentext: {{ stats.with_notentext }}</v-chip>
-        <v-chip color="warning" variant="tonal">Ohne: {{ stats.without }}</v-chip>
+        <v-tooltip
+            text='Lieder mit Status "Bewertet und genommen", die bereits einen Notentext haben'
+            location="bottom"
+        >
+            <template #activator="{ props }">
+                <v-chip v-bind="props" color="success" variant="tonal" prepend-icon="mdi-music-note">
+                    Mit Notentext: {{ stats.with_notentext }}
+                </v-chip>
+            </template>
+        </v-tooltip>
+        <v-tooltip
+            text='Lieder mit Status "Bewertet und genommen", die noch keinen Notentext haben'
+            location="bottom"
+        >
+            <template #activator="{ props }">
+                <v-chip
+                    v-bind="props"
+                    color="warning"
+                    variant="tonal"
+                    prepend-icon="mdi-music-note-off"
+                >
+                    Ohne: {{ stats.without }}
+                </v-chip>
+            </template>
+        </v-tooltip>
     </div>
 
     <v-card class="mb-4">
@@ -1150,8 +1253,8 @@ function formatDate(iso) {
                     </v-btn>
                 </v-btn-toggle>
                 <v-checkbox
-                    v-model="only_rein"
-                    label="Nur Rein"
+                    v-model="only_accepted"
+                    label="Nur Bewertet und genommen"
                     color="success"
                     hide-details
                     density="comfortable"
@@ -1196,10 +1299,10 @@ function formatDate(iso) {
                 <v-spacer />
                 <v-btn
                     color="primary"
-                    :loading="exporting"
-                    :disabled="exporting || selected_count === 0"
+                    :loading="exporting || freshness_checking"
+                    :disabled="exporting || freshness_checking || selected_count === 0"
                     prepend-icon="mdi-download"
-                    @click="runExport"
+                    @click="onExportClick"
                 >
                     {{ selected_count }} PDF(s) + CSV als ZIP exportieren
                 </v-btn>
@@ -1726,6 +1829,48 @@ function formatDate(iso) {
                     @click="confirmDeleteExport"
                 >
                     Löschen
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+
+    <!-- Issue #52: Frische-Warnung – für ausgewählte Lieder existiert im Directus
+         ein neuerer Stand als der geladene. -->
+    <v-dialog v-model="freshness_dialog" max-width="560" persistent>
+        <v-card>
+            <v-card-title class="d-flex align-center ga-2">
+                <v-icon color="warning">mdi-alert</v-icon>
+                Neuerer Stand in Directus
+            </v-card-title>
+            <v-card-text>
+                Für
+                <strong>{{ freshness_stale.length }}</strong>
+                der ausgewählten Lieder gibt es in Directus einen neueren Stand als den geladenen –
+                vermutlich wurde zwischenzeitlich etwas korrigiert. Beim Export würde der
+                <strong>veraltete</strong> Stand verwendet.
+                <ul class="mt-2 mb-1 ps-4">
+                    <li v-for="s in freshness_stale.slice(0, 12)" :key="s.id">{{ s.titel }}</li>
+                </ul>
+                <div v-if="freshness_stale.length > 12" class="text-caption text-medium-emphasis">
+                    … und {{ freshness_stale.length - 12 }} weitere.
+                </div>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn variant="text" :disabled="freshness_checking" @click="freshness_dialog = false">
+                    Abbrechen
+                </v-btn>
+                <v-btn
+                    color="primary"
+                    variant="tonal"
+                    :loading="freshness_checking"
+                    prepend-icon="mdi-refresh"
+                    @click="reloadAndRecheck"
+                >
+                    Daten neu laden
+                </v-btn>
+                <v-btn color="warning" variant="flat" :disabled="freshness_checking" @click="exportAnyway">
+                    Trotzdem exportieren
                 </v-btn>
             </v-card-actions>
         </v-card>

--- a/src/views/NummerngenerierungView.vue
+++ b/src/views/NummerngenerierungView.vue
@@ -1,0 +1,553 @@
+<script setup>
+import { reactive, ref } from 'vue';
+import axios from '@/assets/js/axiossConfig';
+import { planLiednummern, planChoralbuchNummern } from '@/assets/js/nummerngenerierung';
+
+// Superadmin-Werkzeug (Issue #54): portiert die bisher manuell laufenden Skripte
+// 11 (Choralbuchnummer) und 12 (Liednummer 2026) aus gb-scripts in die App,
+// damit Daniel sie selbst ausführen kann. Gefiltert wird – anders als in den
+// Skripten – ausschließlich nach status === 'accepted' ("Bewertet und
+// genommen"), nicht mehr zusätzlich nach der Kleiner-Kreis-Bewertung "Rein".
+//
+// Ablauf je Werkzeug: 1. Vorschau berechnen (nur lesen) → geplante Nummerierung
+// anzeigen, 2. nach Bestätigung in Directus schreiben (nur die geänderten und
+// die obsolet gewordenen Nummern).
+
+const base = import.meta.env.VITE_BACKEND_URL;
+
+const snackbar = ref(false);
+const snackbar_message = ref('');
+
+function errMsg(e) {
+    return (
+        e?.response?.data?.errors?.[0]?.message ||
+        e?.message ||
+        (typeof e === 'string' ? e : 'Unbekannter Fehler')
+    );
+}
+
+// --- Datenzugriff ---------------------------------------------------------
+async function fetchAcceptedSongs(fields) {
+    const resp = await axios.get(`${base}/items/gesangbuchlied`, {
+        params: {
+            filter: JSON.stringify({ status: { _eq: 'accepted' } }),
+            fields,
+            limit: -1,
+        },
+    });
+    return resp.data.data;
+}
+
+async function planLiednummerData() {
+    const [accepted, numbered] = await Promise.all([
+        fetchAcceptedSongs('id,titel,liednummer2026,deutscheLiedfassung'),
+        axios
+            .get(`${base}/items/gesangbuchlied`, {
+                params: {
+                    filter: JSON.stringify({ liednummer2026: { _nnull: true } }),
+                    fields: 'id,titel,liednummer2026',
+                    limit: -1,
+                },
+            })
+            .then((r) => r.data.data),
+    ]);
+    return planLiednummern(accepted, numbered);
+}
+
+async function planChoralbuchData() {
+    const [acceptedRaw, numbered] = await Promise.all([
+        fetchAcceptedSongs('id,melodieId.id,melodieId.titel,melodieId.choralbuchNummer'),
+        axios
+            .get(`${base}/items/melodie`, {
+                params: {
+                    filter: JSON.stringify({ choralbuchNummer: { _nnull: true } }),
+                    fields: 'id,titel,choralbuchNummer',
+                    limit: -1,
+                },
+            })
+            .then((r) => r.data.data),
+    ]);
+    const accepted = acceptedRaw.map((s) => ({ id: s.id, melodie: s.melodieId }));
+    return planChoralbuchNummern(accepted, numbered);
+}
+
+// Schreibvorgänge mit begrenzter Parallelität, damit Directus nicht mit
+// hunderten gleichzeitigen Requests überrannt wird.
+async function runPool(items, worker, concurrency, onProgress) {
+    let index = 0;
+    let done = 0;
+    const failures = [];
+    async function next() {
+        while (index < items.length) {
+            const i = index++;
+            try {
+                await worker(items[i]);
+            } catch (e) {
+                failures.push({ item: items[i], error: errMsg(e) });
+            }
+            done += 1;
+            if (onProgress) onProgress(done, items.length);
+        }
+    }
+    const runners = Array.from({ length: Math.min(concurrency, items.length || 1) }, () => next());
+    await Promise.all(runners);
+    return failures;
+}
+
+async function writePlan(plan, onProgress) {
+    const ops = [
+        ...plan.changed.map((n) => ({ id: n.id, value: n.next })),
+        ...plan.toClear.map((c) => ({ id: c.id, value: null })),
+    ];
+    const failures = await runPool(
+        ops,
+        (op) => axios.patch(`${base}/items/${plan.collection}/${op.id}`, { [plan.field]: op.value }),
+        6,
+        onProgress,
+    );
+    return { total: ops.length, failures };
+}
+
+// --- Werkzeug-Definitionen ------------------------------------------------
+const tools = reactive([
+    {
+        key: 'liednummer',
+        title: 'Liednummer 2026',
+        icon: 'mdi-format-list-numbered',
+        unit: 'Lieder',
+        description:
+            'Vergibt fortlaufende Liednummern (2026) an alle „Bewertet und genommen"-Lieder, sortiert nach Titel. Fremdsprachige Fassungen übernehmen die Nummer ihrer deutschen Liedfassung. Lieder, die nicht mehr genommen sind, verlieren ihre Nummer.',
+        fetch: planLiednummerData,
+        loading: false,
+        writing: false,
+        error: '',
+        plan: null,
+        progress: { done: 0, total: 0 },
+        result: null,
+        expanded: {},
+    },
+    {
+        key: 'choralbuch',
+        title: 'Choralbuchnummer',
+        icon: 'mdi-music-clef-treble',
+        unit: 'Melodien',
+        description:
+            'Vergibt fortlaufende Choralbuchnummern an alle Melodien, die von mindestens einem „Bewertet und genommen"-Lied verwendet werden, sortiert nach Melodie-Titel. Melodien, die nicht mehr verwendet werden, verlieren ihre Nummer.',
+        fetch: planChoralbuchData,
+        loading: false,
+        writing: false,
+        error: '',
+        plan: null,
+        progress: { done: 0, total: 0 },
+        result: null,
+        expanded: {},
+    },
+]);
+
+// Anzeige-Zeilen der durchgehenden Nummerierung (geänderte UND unveränderte in
+// Nummern-Reihenfolge, eine Tabelle). Zusammenhängende Läufe unveränderter Einträge
+// werden – an ihrer richtigen Position – zu einer aufklappbaren Platzhalterzeile
+// zusammengefasst (wie bei einem Diff), statt ans Ende verschoben zu werden.
+function displayRows(plan, tool) {
+    if (!plan) return [];
+    const seq = plan.numbered; // bereits nach neuer Nummer sortiert
+    const out = [];
+    let i = 0;
+    while (i < seq.length) {
+        const n = seq[i];
+        if (n.changed) {
+            out.push({
+                type: 'row',
+                key: `r-${n.id}`,
+                current: n.current,
+                next: n.next,
+                titel: n.titel,
+                changed: true,
+            });
+            i += 1;
+            continue;
+        }
+        // Lauf aufeinanderfolgender unveränderter Einträge einsammeln.
+        let j = i;
+        while (j < seq.length && !seq[j].changed) j += 1;
+        const run = seq.slice(i, j);
+        const runKey = `${run[0].id}_${run[run.length - 1].id}`;
+        if (tool.expanded[runKey]) {
+            for (const u of run) {
+                out.push({
+                    type: 'row',
+                    key: `r-${u.id}`,
+                    current: u.current,
+                    next: u.next,
+                    titel: u.titel,
+                    changed: false,
+                });
+            }
+        } else {
+            out.push({
+                type: 'collapser',
+                key: `co-${runKey}`,
+                runKey,
+                count: run.length,
+                from: run[0].next,
+                to: run[run.length - 1].next,
+            });
+        }
+        i = j;
+    }
+    return out;
+}
+
+// Zu löschende Nummern (Einträge, die ihre Nummer verlieren) – separat, da sie
+// nicht Teil der laufenden Nummerierung sind.
+function clearedRows(plan) {
+    if (!plan) return [];
+    return plan.toClear.map((c) => ({ key: `x-${c.id}`, current: c.current, titel: c.titel }));
+}
+
+function expandRun(tool, runKey) {
+    tool.expanded[runKey] = true;
+}
+
+function collapseAllUnchanged(tool) {
+    tool.expanded = {};
+}
+
+function anyExpanded(tool) {
+    return Object.keys(tool.expanded).length > 0;
+}
+
+async function preview(tool) {
+    tool.loading = true;
+    tool.error = '';
+    tool.result = null;
+    try {
+        tool.plan = await tool.fetch();
+    } catch (e) {
+        tool.error = errMsg(e);
+        tool.plan = null;
+    } finally {
+        tool.loading = false;
+    }
+}
+
+// --- Schreiben (mit Bestätigung) ------------------------------------------
+const confirm_open = ref(false);
+const confirm_tool = ref(null);
+
+function askWrite(tool) {
+    confirm_tool.value = tool;
+    confirm_open.value = true;
+}
+
+async function doWrite() {
+    const tool = confirm_tool.value;
+    confirm_open.value = false;
+    if (!tool || !tool.plan) return;
+
+    tool.writing = true;
+    tool.error = '';
+    tool.result = null;
+    tool.progress = { done: 0, total: tool.plan.changed.length + tool.plan.toClear.length };
+    try {
+        const { total, failures } = await writePlan(tool.plan, (done, t) => {
+            tool.progress = { done, total: t };
+        });
+        tool.result = { ok: total - failures.length, failed: failures.length, failures };
+        snackbar_message.value =
+            failures.length === 0
+                ? `${tool.title}: ${total} Nummern aktualisiert.`
+                : `${tool.title}: ${total - failures.length} aktualisiert, ${failures.length} fehlgeschlagen.`;
+        snackbar.value = true;
+        // Frische Vorschau ziehen – danach sollte nichts mehr „geändert" sein.
+        tool.plan = await tool.fetch();
+    } catch (e) {
+        tool.error = errMsg(e);
+    } finally {
+        tool.writing = false;
+    }
+}
+
+function hasWork(plan) {
+    return !!plan && (plan.counts.changed > 0 || plan.counts.clear > 0);
+}
+</script>
+
+<template>
+    <div class="d-flex align-center flex-wrap ga-2 mb-2">
+        <v-icon class="me-1">mdi-shield-crown</v-icon>
+        <h1>Nummerngenerierung</h1>
+        <v-chip color="error" variant="tonal" size="small" prepend-icon="mdi-account-key">
+            Nur Superadmin
+        </v-chip>
+    </div>
+    <v-alert
+        type="warning"
+        variant="tonal"
+        density="comfortable"
+        class="mb-4"
+        icon="mdi-alert"
+        style="max-width: 900px"
+    >
+        Diese Werkzeuge schreiben direkt in Directus. Berechne zuerst die Vorschau und prüfe die
+        geplanten Änderungen, bevor du schreibst. Grundlage sind ausschließlich Lieder mit Status
+        <strong>„Bewertet und genommen"</strong>.
+    </v-alert>
+
+    <v-row>
+        <v-col v-for="tool in tools" :key="tool.key" cols="12" lg="6">
+            <v-card class="h-100">
+                <v-card-title class="d-flex align-center ga-2">
+                    <v-icon>{{ tool.icon }}</v-icon>
+                    {{ tool.title }}
+                </v-card-title>
+                <v-card-text>
+                    <p class="text-body-2 text-medium-emphasis mb-3">{{ tool.description }}</p>
+
+                    <div class="d-flex flex-wrap ga-2 mb-3">
+                        <v-btn
+                            color="primary"
+                            variant="tonal"
+                            prepend-icon="mdi-eye"
+                            :loading="tool.loading"
+                            :disabled="tool.writing"
+                            @click="preview(tool)"
+                        >
+                            Vorschau berechnen
+                        </v-btn>
+                        <v-btn
+                            color="error"
+                            prepend-icon="mdi-database-edit"
+                            :disabled="!hasWork(tool.plan) || tool.loading || tool.writing"
+                            @click="askWrite(tool)"
+                        >
+                            In Directus schreiben
+                        </v-btn>
+                    </div>
+
+                    <v-alert
+                        v-if="tool.error"
+                        type="error"
+                        variant="tonal"
+                        density="compact"
+                        class="mb-3"
+                    >
+                        {{ tool.error }}
+                    </v-alert>
+
+                    <div v-if="tool.writing" class="mb-3">
+                        <div class="text-caption mb-1">
+                            Schreibe … {{ tool.progress.done }} / {{ tool.progress.total }}
+                        </div>
+                        <v-progress-linear
+                            :model-value="
+                                tool.progress.total
+                                    ? (tool.progress.done / tool.progress.total) * 100
+                                    : 0
+                            "
+                            color="error"
+                            height="6"
+                            rounded
+                        />
+                    </div>
+
+                    <v-alert
+                        v-if="tool.result"
+                        :type="tool.result.failed ? 'warning' : 'success'"
+                        variant="tonal"
+                        density="compact"
+                        class="mb-3"
+                    >
+                        {{ tool.result.ok }} Nummern geschrieben<span v-if="tool.result.failed">
+                            , {{ tool.result.failed }} fehlgeschlagen</span
+                        >.
+                    </v-alert>
+
+                    <template v-if="tool.plan">
+                        <div class="d-flex flex-wrap ga-2 mb-3">
+                            <v-chip size="small" variant="tonal" prepend-icon="mdi-counter">
+                                {{ tool.plan.counts.total }} zu nummerieren
+                            </v-chip>
+                            <v-chip
+                                size="small"
+                                :color="tool.plan.counts.changed ? 'primary' : undefined"
+                                variant="tonal"
+                                prepend-icon="mdi-pencil"
+                            >
+                                {{ tool.plan.counts.changed }} Änderungen
+                            </v-chip>
+                            <v-chip size="small" variant="tonal" prepend-icon="mdi-check">
+                                {{ tool.plan.counts.unchanged }} unverändert
+                            </v-chip>
+                            <v-chip
+                                size="small"
+                                :color="tool.plan.counts.clear ? 'warning' : undefined"
+                                variant="tonal"
+                                prepend-icon="mdi-eraser"
+                            >
+                                {{ tool.plan.counts.clear }} zu löschen
+                            </v-chip>
+                            <v-chip
+                                v-if="tool.plan.counts.skipped"
+                                size="small"
+                                color="warning"
+                                variant="tonal"
+                                prepend-icon="mdi-debug-step-over"
+                            >
+                                {{ tool.plan.counts.skipped }} übersprungen
+                            </v-chip>
+                            <v-chip
+                                v-if="tool.plan.counts.skippedNoMelodie"
+                                size="small"
+                                variant="tonal"
+                                prepend-icon="mdi-music-note-off"
+                            >
+                                {{ tool.plan.counts.skippedNoMelodie }} ohne Melodie
+                            </v-chip>
+                        </div>
+
+                        <p
+                            v-if="!hasWork(tool.plan)"
+                            class="text-body-2 text-success d-flex align-center ga-1"
+                        >
+                            <v-icon size="small">mdi-check-circle</v-icon>
+                            Alle Nummern sind bereits aktuell – nichts zu schreiben.
+                        </p>
+
+                        <div v-if="tool.plan.numbered.length || clearedRows(tool.plan).length">
+                            <div v-if="anyExpanded(tool)" class="d-flex justify-end mb-1">
+                                <v-btn
+                                    size="x-small"
+                                    variant="text"
+                                    prepend-icon="mdi-unfold-less-horizontal"
+                                    @click="collapseAllUnchanged(tool)"
+                                >
+                                    Unveränderte wieder einklappen
+                                </v-btn>
+                            </div>
+
+                            <div v-if="tool.plan.numbered.length" class="preview-box">
+                                <v-table density="compact" hover>
+                                    <thead>
+                                        <tr>
+                                            <th style="width: 130px">Nr.</th>
+                                            <th>Titel</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <template
+                                            v-for="row in displayRows(tool.plan, tool)"
+                                            :key="row.key"
+                                        >
+                                            <tr
+                                                v-if="row.type === 'collapser'"
+                                                class="collapser-row"
+                                                @click="expandRun(tool, row.runKey)"
+                                            >
+                                                <td colspan="2" class="text-medium-emphasis">
+                                                    <v-icon size="small" class="me-1">
+                                                        mdi-chevron-right
+                                                    </v-icon>
+                                                    {{ row.count }} unveränderte {{ tool.unit }}
+                                                    (Nr. {{ row.from }}–{{ row.to }}) anzeigen
+                                                </td>
+                                            </tr>
+                                            <tr
+                                                v-else
+                                                :class="{ 'text-medium-emphasis': !row.changed }"
+                                            >
+                                                <td>
+                                                    <template v-if="row.changed">
+                                                        <span class="text-medium-emphasis">
+                                                            {{ row.current ?? '–' }}
+                                                        </span>
+                                                        <v-icon size="x-small" class="mx-1">
+                                                            mdi-arrow-right
+                                                        </v-icon>
+                                                        <strong>{{ row.next }}</strong>
+                                                    </template>
+                                                    <template v-else>{{ row.next }}</template>
+                                                </td>
+                                                <td>{{ row.titel }}</td>
+                                            </tr>
+                                        </template>
+                                    </tbody>
+                                </v-table>
+                            </div>
+
+                            <template v-if="clearedRows(tool.plan).length">
+                                <div
+                                    class="d-flex align-center ga-1 text-subtitle-2 font-weight-bold mt-3 mb-1"
+                                >
+                                    <v-icon size="small">mdi-eraser</v-icon>
+                                    Zu löschen ({{ clearedRows(tool.plan).length }})
+                                </div>
+                                <div class="preview-box">
+                                    <v-table density="compact" hover>
+                                        <tbody>
+                                            <tr v-for="row in clearedRows(tool.plan)" :key="row.key">
+                                                <td style="width: 130px">
+                                                    <span class="text-medium-emphasis">
+                                                        {{ row.current ?? '–' }}
+                                                    </span>
+                                                    <v-icon size="x-small" class="mx-1">
+                                                        mdi-arrow-right
+                                                    </v-icon>
+                                                    <span class="text-warning">leer</span>
+                                                </td>
+                                                <td>{{ row.titel }}</td>
+                                            </tr>
+                                        </tbody>
+                                    </v-table>
+                                </div>
+                            </template>
+                        </div>
+                    </template>
+                </v-card-text>
+            </v-card>
+        </v-col>
+    </v-row>
+
+    <v-dialog v-model="confirm_open" max-width="480">
+        <v-card>
+            <v-card-title class="d-flex align-center ga-2">
+                <v-icon color="error">mdi-alert</v-icon>
+                Schreiben bestätigen
+            </v-card-title>
+            <v-card-text v-if="confirm_tool">
+                <strong>{{ confirm_tool.title }}</strong> in Directus schreiben?
+                <div class="mt-2">
+                    {{ confirm_tool.plan?.counts.changed }} Nummern werden geändert,
+                    {{ confirm_tool.plan?.counts.clear }} werden gelöscht. Dies kann nicht
+                    rückgängig gemacht werden.
+                </div>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer />
+                <v-btn variant="text" @click="confirm_open = false">Abbrechen</v-btn>
+                <v-btn color="error" variant="flat" @click="doWrite">Ja, schreiben</v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+
+    <v-snackbar v-model="snackbar" :timeout="4000">
+        {{ snackbar_message }}
+        <template #actions>
+            <v-btn variant="text" @click="snackbar = false">OK</v-btn>
+        </template>
+    </v-snackbar>
+</template>
+
+<style scoped>
+.preview-box {
+    max-height: 55vh;
+    overflow-y: auto;
+}
+.collapser-row {
+    cursor: pointer;
+    user-select: none;
+}
+.collapser-row:hover {
+    background: rgba(var(--v-theme-primary), 0.06);
+}
+</style>


### PR DESCRIPTION
#47 Korrekturansicht: Liednummer 2026 (inkl. Auflösung über deutsche
     Liedfassung) vor dem Titel anzeigen.
#48 Notentext-Export: Obergrenze der Lücken-Anzeige ist jetzt die höchste
     insgesamt vergebene Liednummer 2026 statt nur der exportierbaren.
#49 Notentext-Export: Checkbox „Nur Rein" → „Nur Bewertet und genommen",
     Filter auf status=accepted; Zahlenübersicht nur noch über genommene
     Lieder (Mit Notentext / Ohne, „Gesamt" entfällt).
#50 Inhaltsverzeichnis-Export: differenzierte Kennzahlen (gesamt, gleiche
     Liednummer, höchste Nummer, ohne Nummer) mit Icons.
#51 Inhaltsverzeichnis-Export: Checkbox → „Nur Bewertet und genommen",
     Filter auf status=accepted.
#52 „Zurückgesetzte" Strophentexte: Ursache war der Service-Worker-Cache
     (cache-first, bis 1 h) für /items. Auf network-first umgestellt
     (Cache nur noch Offline-Fallback), Cache-Version erhöht. Zusätzlich
     Konflikterkennung: Warnung beim Speichern, wenn der Text zwischenzeitlich
     geändert wurde, und Frische-Warnung vor dem Notentext-Export.
#54 Neue Superadmin-Ansicht /nummerngenerierung: portiert die Skripte 11
     (Choralbuchnummer) und 12 (Liednummer 2026) in die App – Vorschau als
     Diff (unveränderte Einträge in der Tabelle ein-/ausklappbar) und
     Schreiben nach Bestätigung. Filter nur noch status=accepted; Sortierung
     ignoriert Satz-/Sonderzeichen. Zugriff via VITE_SUPERADMIN_ROLES.